### PR TITLE
Add flag "--extra-roles" for dependencies.

### DIFF
--- a/cmd/full.go
+++ b/cmd/full.go
@@ -23,11 +23,12 @@ package cmd
 import (
 	"os"
 
+	"fmt"
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/fubarhouse/ansible-role-tester/util"
 	"github.com/spf13/cobra"
-	"fmt"
-	"strings"
 )
 
 // fullCmd represents the full command
@@ -50,10 +51,11 @@ required.
 		config := util.AnsibleConfig{
 			HostPath:         source,
 			RemotePath:       destination,
+			ExtraRolesPath:   extraRoles,
 			RequirementsFile: requirements,
 			PlaybookFile:     playbook,
 			Verbose:          verbose,
-			Quiet:			  quiet,
+			Quiet:            quiet,
 		}
 
 		var dist util.Distribution
@@ -120,6 +122,7 @@ func init() {
 	fullCmd.Flags().StringVarP(&source, "source", "s", pwd, "Location of the role to test")
 	fullCmd.Flags().StringVarP(&destination, "destination", "d", "/etc/ansible/roles/role_under_test", "Location which the role will be mounted to")
 	fullCmd.Flags().StringVarP(&requirements, "requirements", "r", "", "Path to requirements file.")
+	fullCmd.Flags().StringVarP(&extraRoles, "extra-roles", "e", "", "Path to roles folder with dependencies.")
 	fullCmd.Flags().StringVarP(&playbook, "playbook", "p", "playbook.yml", "The filename of the playbook")
 	fullCmd.Flags().BoolVarP(&noOutput, "no-output", "o", false, "Hide output from all Docker commands")
 	fullCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Enable quiet mode")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,10 @@ var (
 	// Path to the requirements file relative to source.
 	requirements string
 
+	// extraRoles is an optional argument for binding a
+	// host folder with roles into the container
+	extraRoles string
+
 	// playbook is the path to the playbook to execute inside of
 	// the 'tests' folder.
 	playbook string

--- a/util/util.go
+++ b/util/util.go
@@ -1,9 +1,10 @@
 package util
 
 import (
-	log "github.com/Sirupsen/logrus"
-	"os/exec"
 	"os"
+	"os/exec"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 var (
@@ -33,6 +34,12 @@ type AnsibleConfig struct {
 	// RemotePath is the path to the roles folder on the container
 	// which should represent the roles folder (ie /etc/ansible/roles)
 	RemotePath string
+
+	// ExtraRolesPath is the path to the roles folder on the host which will
+	// be mounted on the container to "/root/.ansible/roles" and available to the playbook
+	// as dependencies. This is a useful workaround for CI/CD environments where the roles
+	// are already downloaded on the host, or if the roles are in private git repos.
+	ExtraRolesPath string
 
 	// The path to the requirements file relative to HostPath.
 	// Requirements will not attempt installation if the field


### PR DESCRIPTION
See fubarhouse/ansible-role-tester#28 for discussion.

Note that some of the deltas were caused `go fmt`.

I did not run `dep ensure` or touch vendor. 