### PR TITLE
Add "extra-roles" flag to run, and fix bug in test command.

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,11 +23,12 @@ package cmd
 import (
 	"os"
 
+	"fmt"
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/fubarhouse/ansible-role-tester/util"
 	"github.com/spf13/cobra"
-	"fmt"
-	"strings"
 )
 
 // runCmd represents the dockerRun command
@@ -42,10 +43,11 @@ Volume mount locations image and id are all configurable.
 		config := util.AnsibleConfig{
 			HostPath:         source,
 			RemotePath:       destination,
+			ExtraRolesPath:   extraRoles,
 			RequirementsFile: "",
 			PlaybookFile:     "",
 			Verbose:          verbose,
-			Quiet:			  quiet,
+			Quiet:            quiet,
 		}
 
 		var dist util.Distribution
@@ -95,6 +97,7 @@ func init() {
 	runCmd.Flags().StringVarP(&containerID, "name", "n", containerID, "Container ID")
 	runCmd.Flags().StringVarP(&source, "source", "s", pwd, "Location of the role to test")
 	runCmd.Flags().StringVarP(&destination, "destination", "d", "/etc/ansible/roles/role_under_test", "Location which the role will be mounted to")
+	runCmd.Flags().StringVarP(&extraRoles, "extra-roles", "e", "", "Path to roles folder with dependencies.")
 	runCmd.Flags().BoolVarP(&custom, "custom", "c", false, "Provide my own custom distribution.")
 	runCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Enable quiet mode")
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -41,7 +41,7 @@ containers won't be removed after completion.`,
 			RequirementsFile: requirements,
 			PlaybookFile:     playbook,
 			Verbose:          verbose,
-			Quiet:			  quiet,
+			Quiet:            quiet,
 		}
 
 		dist, _ := util.GetDistribution(image, image, "/sbin/init", "/sys/fs/cgroup:/sys/fs/cgroup:ro", user, distro)
@@ -63,6 +63,7 @@ containers won't be removed after completion.`,
 func init() {
 	rootCmd.AddCommand(testCmd)
 	testCmd.Flags().StringVarP(&containerID, "name", "n", containerID, "Container ID")
+	testCmd.Flags().StringVarP(&destination, "destination", "d", "/etc/ansible/roles/role_under_test", "Location which the role was mounted to")
 	testCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose mode for Ansible commands.")
 	testCmd.Flags().StringVarP(&playbook, "playbook", "p", "playbook.yml", "The filename of the playbook")
 	testCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Enable quiet mode")


### PR DESCRIPTION
- In #28 there was a flag added called "extra-roles". Per discussion,
adding it to the run command as well.
- The test command did not have the "destination" flag,
which meant that containers launched using the run command with that
flag specified could not be tested. Added the flag and updated the
config.