### PR TITLE
PR for #48

### DIFF
--- a/util/ansible.go
+++ b/util/ansible.go
@@ -114,7 +114,7 @@ func (dist *Distribution) RoleTestRemote(config *AnsibleConfig) {
 func AnsiblePlaybook(args []string, stdout bool) (string, error) {
 
 	// If we haven't found Ansible yet, we should look for it.
-	if ansibleplaybook != "" {
+	if ansibleplaybook == "" {
 		a, e := exec.LookPath("ansible-playbook")
 		if e != nil {
 			log.Errorln("executable 'ansible-playbook' was not found in $PATH.")

--- a/util/ansible.go
+++ b/util/ansible.go
@@ -113,6 +113,15 @@ func (dist *Distribution) RoleTestRemote(config *AnsibleConfig) {
 // You can request output be printed using the bool stdout.
 func AnsiblePlaybook(args []string, stdout bool) (string, error) {
 
+	// If we haven't found Ansible yet, we should look for it.
+	if ansibleplaybook != "" {
+		a, e := exec.LookPath("ansible-playbook")
+		if e != nil {
+			log.Errorln("executable 'ansible-playbook' was not found in $PATH.")
+		}
+		ansibleplaybook = a
+	}
+
 	// Generate the command, based on input.
 	cmd := exec.Cmd{}
 	cmd.Path = ansibleplaybook

--- a/util/util.go
+++ b/util/util.go
@@ -92,10 +92,4 @@ func init() {
 	docker = d
 	dockerFound = true
 
-	a, e := exec.LookPath("ansible-playbook")
-	if e != nil {
-		log.Errorln("executable 'ansible-playbook' was not found in $PATH.")
-	}
-	ansibleplaybook = a
-
 }

--- a/util/util.go
+++ b/util/util.go
@@ -94,12 +94,10 @@ func init() {
 	docker = d
 	dockerFound = true
 
-	if dockerFound {
-		c, err := net.Dial("unix", "/var/run/docker.sock")
-		if err != nil {
-			log.Fatalf("unable to connect to docker: %v", err)
-		}
-		defer c.Close()
+	c, err := net.Dial("unix", "/var/run/docker.sock")
+	if err != nil {
+		log.Fatalf("unable to connect to docker: %v", err)
 	}
+	defer c.Close()
 
 }

--- a/util/util.go
+++ b/util/util.go
@@ -94,10 +94,12 @@ func init() {
 	docker = d
 	dockerFound = true
 
-	c, err := net.Dial("unix", "/var/run/docker.sock")
-	if err != nil {
-		log.Fatalf("unable to connect to docker: %v", err)
+	if dockerFound {
+		c, err := net.Dial("unix", "/var/run/docker.sock")
+		if err != nil {
+			log.Fatalf("unable to connect to docker: %v", err)
+		}
+		defer c.Close()
 	}
-	defer c.Close()
 
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"net"
 	"os"
 	"os/exec"
 
@@ -89,7 +90,14 @@ func init() {
 		log.Errorln("executable 'docker' was not found in $PATH.")
 		os.Exit(1)
 	}
+
 	docker = d
 	dockerFound = true
+
+	c, err := net.Dial("unix", "/var/run/docker.sock")
+	if err != nil {
+		log.Fatalf("unable to connect to docker: %v", err)
+	}
+	defer c.Close()
 
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"net"
 	"os"
 	"os/exec"
 
@@ -90,14 +89,7 @@ func init() {
 		log.Errorln("executable 'docker' was not found in $PATH.")
 		os.Exit(1)
 	}
-
 	docker = d
 	dockerFound = true
-
-	c, err := net.Dial("unix", "/var/run/docker.sock")
-	if err != nil {
-		log.Fatalf("unable to connect to docker: %v", err)
-	}
-	defer c.Close()
 
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"net"
 	"os"
 	"os/exec"
 
@@ -89,7 +90,16 @@ func init() {
 		log.Errorln("executable 'docker' was not found in $PATH.")
 		os.Exit(1)
 	}
+
 	docker = d
 	dockerFound = true
+
+	if dockerFound {
+		c, err := net.Dial("unix", "/var/run/docker.sock")
+		if err != nil {
+			log.Fatalf("unable to connect to docker: %v", err)
+		}
+		defer c.Close()
+	}
 
 }


### PR DESCRIPTION
Changes described in #48, priority bug report.

* Moves detection of Ansible to a more appropriate spot - so systems can use the tool without having Ansible installed, and Ansible is still detected (only when using `--remote`.
* Adds the detection of Docker's daemon on UNIX-based systems (Linux, Mac), which will provide for actual useful debugging information in the event the daemon is not started, instead of providing an empty fatal error.