### PR TITLE
Add "--library" flag.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_install:
   - cp -rf $TRAVIS_BUILD_DIR/* $GOPATH/src/github.com/fubarhouse/ansible-role-tester/
   - cd $GOPATH/src/github.com/fubarhouse/ansible-role-tester/ && go install ./...
   - git clone https://github.com/fubarhouse/ansible-role-curl.git /home/travis/my_role
+  - git clone https://github.com/issmirnov/ansible-role-art-tester.git /home/travis/ansible-role-art-tester
 
 script:
   # Test the role from inside the container using the segmented commands.
@@ -60,3 +61,5 @@ script:
   - sed -i -e 's/role_under_test/\/home\/travis\/my_role\//g' /home/travis/my_role/tests/test-package.yml
   # Test the role from outside the container using the one standard pipeline command.
   - cd /home/travis/my_role && ansible-role-tester full --name travis_test --user fubarhouse --distribution ${distro} --playbook tests/test-package.yml --remote
+  # Phase 2: test other flags
+  - cd /home/travis/ansible-role-art-tester &&  ansible-role-tester full --playbook tests/playbook-library.yml --library "$(pwd)/tests/library"

--- a/cmd/full.go
+++ b/cmd/full.go
@@ -53,6 +53,7 @@ required.
 			Inventory:        inventory,
 			RemotePath:       destination,
 			ExtraRolesPath:   extraRoles,
+			LibraryPath:      libraryPath,
 			RequirementsFile: requirements,
 			PlaybookFile:     playbook,
 			Verbose:          verbose,
@@ -145,6 +146,7 @@ func init() {
 	fullCmd.Flags().BoolVarP(&remote, "remote", "m", false, "Run the test remotely to the container")
 	fullCmd.Flags().BoolVarP(&reportProvided, "report", "f", false, "Provide a report after completion")
 	fullCmd.Flags().StringVarP(&reportFilename, "report-output", "b", "report.yml", "Filename in current working directory to write a report to")
+	fullCmd.Flags().StringVarP(&libraryPath, "library", "", "", "Path to library folder with modules.")
 
 	fullCmd.Flags().StringVarP(&initialise, "initialise", "a", "/bin/systemd", "The initialise command for the image")
 	fullCmd.Flags().StringVarP(&volume, "volume", "l", "/sys/fs/cgroup:/sys/fs/cgroup:ro", "The volume argument for the image")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,10 @@ var (
 	// the 'tests' folder.
 	playbook string
 
+	// libraryPath is an optional argument for binding a
+	// host folder with ansible modules into the container
+	libraryPath string
+
 	// user is the optional argument which specifies the
 	// user associated to the selected distribution, which
 	// will be used to locate a Distribution with the same user.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -45,6 +45,7 @@ Volume mount locations image and id are all configurable.
 			Inventory:        inventory,
 			RemotePath:       destination,
 			ExtraRolesPath:   extraRoles,
+			LibraryPath:      libraryPath,
 			RequirementsFile: requirements,
 			PlaybookFile:     playbook,
 			Verbose:          verbose,
@@ -116,6 +117,7 @@ func init() {
 	runCmd.Flags().BoolVarP(&custom, "custom", "c", false, "Provide my own custom distribution.")
 	runCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Enable quiet mode")
 	runCmd.Flags().BoolVarP(&remote, "remote", "m", false, "Run the test remotely to the container")
+	runCmd.Flags().StringVarP(&libraryPath, "library", "", "", "Path to library folder with modules.")
 
 	runCmd.Flags().StringVarP(&initialise, "initialise", "a", "/bin/systemd", "The initialise command for the image")
 	runCmd.Flags().StringVarP(&volume, "volume", "l", "/sys/fs/cgroup:/sys/fs/cgroup:ro", "The volume argument for the image")

--- a/util/docker.go
+++ b/util/docker.go
@@ -108,6 +108,9 @@ func buildDockerArgs(dist *Distribution, config *AnsibleConfig) []string {
 	if config.ExtraRolesPath != "" {
 		dockerArgs = append(dockerArgs, fmt.Sprintf("--volume=%s:%v", config.ExtraRolesPath, "/root/.ansible/roles"))
 	}
+	if config.LibraryPath != "" {
+		dockerArgs = append(dockerArgs, fmt.Sprintf("--volume=%s:%v", config.LibraryPath, "/root/.ansible/plugins/modules"))
+	}
 	if dist.Privileged {
 		dockerArgs = append(dockerArgs, fmt.Sprint("--privileged"))
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -52,6 +52,10 @@ type AnsibleConfig struct {
 	// are already downloaded on the host, or if the roles are in private git repos.
 	ExtraRolesPath string
 
+	// LibraryPath is the path to the library folder on the host which will
+	// be mounted on the container to "/root/.ansible/library".
+	LibraryPath string
+
 	// The path to the requirements file relative to HostPath.
 	// Requirements will not attempt installation if the field
 	// does not have a value (when value == "")


### PR DESCRIPTION
@fubarhouse 

I'm using [concourse](https://concourse-ci.org/) to set up some pipelines for my various ansible roles. So far it's been fantastic - ansible-role-tester works perfectly and enabled me to delete the majority of my boilerplate.

As part of my testing I use [goss](https://github.com/aelsabbahy/goss) to perform acceptance testing of my roles, powered by the [indusbox/goss-ansible](https://github.com/indusbox/goss-ansible/) module. This required adding a `--library` mount to docker container under the default search path for modules, which seems to be either `/root/.ansible/plugins/modules` or `/usr/share/ansible/plugins/modules`.

I've added a `--library` flag that works similar to `--extra-roles` and mounts the specified directory to `/root/.ansible/plugins/modules`.

To test this, I've created a sample repo at [issmirnov/ansible-role-art-tester](https://github.com/issmirnov/ansible-role-art-tester) that contains a dummy module and various permutations of playbooks. The travis config has been updated to exercise the new repository.

Let me know what you think - happy to adjust the PR as needed.