### PR TITLE
PR for #74

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/fubarhouse/ansible-role-tester
 
 require (
 	github.com/inconshreveable/mousetrap v1.0
-	github.com/Sirupsen/logrus v1.1.0
+	github.com/sirupsen/logrus v1.1.0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.2
 	golang.org/x/crypto v0.0.0-20180617042118-027cca12c2d6


### PR DESCRIPTION
#74 identified a broken reference to the Logrus package, where the user name was previously was capitalised and is no longer.

Initial tests have verified by simply fixing the user name reference, Go modules will start to work as normal.