### PR TITLE
Replace custom logic with filepath.Base

### DIFF
--- a/util/docker.go
+++ b/util/docker.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"fmt"
@@ -103,8 +104,8 @@ func buildDockerArgs(dist *Distribution, config *AnsibleConfig, report *AnsibleR
 	// than the role_under_test convention.
 	if !config.Remote {
 		pwd, _ := os.Getwd()
-		pwds := strings.Split(pwd, string(os.PathSeparator))
-		report.Docker.Volumes = append(report.Docker.Volumes, fmt.Sprintf("%s:/etc/ansible/roles/%v", config.HostPath, pwds[len(pwds)-1]))
+		dir := filepath.Base(pwd)
+		report.Docker.Volumes = append(report.Docker.Volumes, fmt.Sprintf("%s:/etc/ansible/roles/%v", config.HostPath, dir))
 	}
 
 	if config.ExtraRolesPath != "" {


### PR DESCRIPTION
There's a useful function at https://golang.org/pkg/path/filepath/#Base that handles this cleanly.