### PR TITLE
Use config.HostPath rather than pwd for mount

### DIFF
--- a/util/docker.go
+++ b/util/docker.go
@@ -103,9 +103,8 @@ func buildDockerArgs(dist *Distribution, config *AnsibleConfig, report *AnsibleR
 	// so we can call the roles by name in the playbook, rather
 	// than the role_under_test convention.
 	if !config.Remote {
-		pwd, _ := os.Getwd()
-		dir := filepath.Base(pwd)
-		report.Docker.Volumes = append(report.Docker.Volumes, fmt.Sprintf("%s:/etc/ansible/roles/%v", config.HostPath, dir))
+		roleDir := filepath.Base(config.HostPath)
+		report.Docker.Volumes = append(report.Docker.Volumes, fmt.Sprintf("%s:/etc/ansible/roles/%v", config.HostPath, roleDir))
 	}
 
 	if config.ExtraRolesPath != "" {


### PR DESCRIPTION
This binary might be invoked from any location in the filesystem. Since the role directory is either provided via the --source flag, or defaults to PWD, we can simply pull the basename from the config struct to get the name of the role.

Closes #79 