### PR TITLE
Fix bug in util.MapPlaybook

### DIFF
--- a/util/mapper.go
+++ b/util/mapper.go
@@ -75,8 +75,9 @@ func GenericPlaybookAssignment(input, path string) (string, error) {
 func MapPlaybook(config *AnsibleConfig) {
 
 	playbook, err := GenericFileAssignment(config.PlaybookFile, config.HostPath, true)
-	playbook, err = GenericPlaybookAssignment(config.PlaybookFile, config.HostPath)
-
+	if err != nil {
+		playbook, err = GenericPlaybookAssignment(config.PlaybookFile, config.HostPath)
+	}
 	config.PlaybookFile = playbook
 
 	if err != nil {


### PR DESCRIPTION
If a user passes the "--playbook" flag to the "test" command
where the test folder contains a file called "playbook.yml", the
"--playbook" command will be ignored in favor of the "playbook.yml"
default.

This case is not caught by the current travis configs, as the
https://github.com/fubarhouse/ansible-role-curl/tree/master/tests
folder does not contain a "playbook.yml"