### PR TITLE
Ignore compiled binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ vendor/*
 
 # reports
 **/report.yml
+
+## compiled binaries (go build .)
+ansible-role-tester


### PR DESCRIPTION
When iterating locally, sometimes it's useful to run a "go build ."

Adding an ignore for the binaries.