### PR TITLE
#115: Update Go version during testing to v1.12.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: go
 go:
-  - "1.11"
+  - "1.12.4"
 
 python:
   - 2.7


### PR DESCRIPTION
Fixes #115 

Update Go to the latest version in the automated tests.