### PR TITLE
Change clone url from git to https schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ None.
 
 ### Building from source
 ```sh
-git clone git@github.com:fubarhouse/ansible-role-tester.git
+git clone https://github.com/fubarhouse/ansible-role-tester.git
 cd ansible-role-tester
 GO111MODULE=on go mod download
 GO111MODULE=on go build .


### PR DESCRIPTION
Those users that don't have edit rights on this repo are denied the download. For simple installation from HEAD, the https url is optimal.

Error:
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.