### PR TITLE
Add support for ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
   - distro: ubuntu1804
   - distro: ubuntu1810
   - distro: ubuntu1904
+  - distro: ubuntu2004
   - distro: centos6
   - distro: centos7
   - distro: debian8

--- a/util/distributions.go
+++ b/util/distributions.go
@@ -394,6 +394,17 @@ var Ubuntu1904 = Distribution{
 	Ubuntu,
 }
 
+// Ubuntu2004 Distribution declaration
+var Ubuntu2004 = Distribution{
+	"",
+	"ubuntu2004",
+	true,
+	"fubarhouse/docker-ansible:focal",
+	"fubarhouse",
+	"ubuntu2004",
+	Ubuntu,
+}
+
 // JeffCentOS6 Distribution declaration
 var JeffCentOS6 = Distribution{
 	"",
@@ -535,6 +546,7 @@ var Distributions = []Distribution{
 	Ubuntu1804,
 	Ubuntu1810,
 	Ubuntu1904,
+	Ubuntu2004,
 	JeffCentOS6,
 	JeffCentOS7,
 	JeffUbuntu1204,


### PR DESCRIPTION
I see that [https://hub.docker.com/layers/fubarhouse/docker-ansible/focal](https://hub.docker.com/layers/fubarhouse/docker-ansible/focal/images/sha256-b9a65a1d962d27a46b90572d49feab57472fb0e8be1650e918641f1f1d3e58cf?context=explore) exists, as does https://hub.docker.com/r/fubarhouse/docker-ubuntu2004-ansible

Adding official support for Ubuntu 20.04 to ART.

Please let me know if there's more that needs to be done.